### PR TITLE
Linux makefile install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+clean:
+	-rm -r dist &> /dev/null
+	-rm -r node_modules &> /dev/null
+
+build-npm:
+	npm install
+	./node_modules/.bin/tsc
+
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+build-linux:
+	echo "#!/bin/bash" > dist/aghblock.sh
+	echo "NODE_PATH=${ROOT_DIR}" >> dist/aghblock.sh
+	echo "cd \$$NODE_PATH/dist" >> dist/aghblock.sh
+	echo "NODE_PATH=\$$NODE_PATH node index.js \"\$$@\"" >> dist/aghblock.sh
+	ln -f dist/aghblock.sh /usr/bin/aghblock
+	chmod 750 /usr/bin/aghblock
+
+install: clean build-npm build-linux


### PR DESCRIPTION
Added a Makefile to install in Linux quickly:

1.- Clean any previous build / installed modules.
2.- Install npm modules.
3.- Transpile TypeScript.
4.- Generate a bash script to execute the script from anywhere.
5.- Create a link to a path directory.
